### PR TITLE
ImageCache - `loadImages` add .catch to Promise.all to handle reject; IE11 cached images race condition fix

### DIFF
--- a/modules/ImageHelper.js
+++ b/modules/ImageHelper.js
@@ -9,19 +9,35 @@ const ImageHelper = {
                 resolve(image);
             };
             const handleError = () => {
-                reject(image);
+                reject(new Error('failed to preload ' + url));
             };
 
             if (image.complete) {
                 // image is loaded, go ahead and change the state
 
-                if(image.naturalWidth && image.naturalHeight) {
-                    // successful load
-                    handleSuccess();
-                } else {
-                    handleError();
-                }
-
+                    if (image.naturalWidth && image.naturalHeight) {
+                        // successful load
+                        handleSuccess();
+                    } else {
+                        // IE CACHED IMAGES RACE CONDITION
+                        // -------------------------------
+                        // IE11 sometimes reports cached images as image.complete,
+                        // but naturalWidth and naturalHeight = 0.
+                        // A few ms later it will get the dimensions correct,
+                        // so check a few times before rejecting it.
+                        let counter = 1;
+                        const checkDimensions = setInterval(() => {
+                            if (image.naturalWidth && image.naturalHeight) {
+                                window.clearInterval(checkDimensions);
+                                handleSuccess();
+                            }
+                            if (counter === 3) {
+                                window.clearInterval(checkDimensions);
+                                handleError();
+                            }
+                            counter++;
+                        }, 50);
+                    }
             } else {
                 image.addEventListener('load', handleSuccess, false);
                 image.addEventListener('error', handleError, false);
@@ -31,7 +47,9 @@ const ImageHelper = {
 
     loadImages(urls, options) {
         const promises = urls.map(url =>  this.loadImage(url, options));
-        return Promise.all(promises);
+        return Promise.all(promises).catch((err) => {
+            console.warn(err.message);
+        });
     },
 
     // preload without caring about the result


### PR DESCRIPTION
This commit fixes IE throwing 'unhandled promise rejection' when the Promise is rejected.

IE11 sometimes reports cached images as image.complete, but naturalWidth and naturalHeight = 0. A few ms later it will get the dimensions correct, so check a few times before rejecting it.
