### PR TITLE
Use the prop-types package instead of deprecated PropTypes from React

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,31 +40,31 @@ var images = [];
 ```javascript
    propTypes: {
 		//Rendered on success
-		children: React.PropTypes.element.isRequired,
+		children: PropTypes.element.isRequired,
 
 		//Rendered during load
-		loadingIndicator: React.PropTypes.node.isRequired,
+		loadingIndicator: PropTypes.node.isRequired,
 
 		//Array of image urls to be preloaded
-		images: React.PropTypes.array,
+		images: PropTypes.array,
 
 		//If set, the preloader will automatically show
 		//the children content after this amount of time
-		autoResolveDelay: React.PropTypes.number,
+		autoResolveDelay: PropTypes.number,
 
 		//Error callback. Is passed the error
-		onError: React.PropTypes.func,
+		onError: PropTypes.func,
 
 		//Success callback
-		onSuccess: React.PropTypes.func,
+		onSuccess: PropTypes.func,
 
 		//Whether or not we should still show the content
 		//even if there is a preloading error
-		resolveOnError: React.PropTypes.bool
+		resolveOnError: PropTypes.bool
 
         //Whether or not we should mount the child content after
         //images have finished loading (or after autoResolveDelay)
-        mountChildren: React.PropTypes.bool
+        mountChildren: PropTypes.bool
     }
 ```
 

--- a/modules/Preload.js
+++ b/modules/Preload.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ImageHelper from './ImageHelper';
 
 const propTypes = {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "react": ">=15.0.0",
     "react-dom": ">=15.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Use the prop-types package instead of deprecated PropTypes from main React Package.

![screen shot 2017-05-24 at 3 36 23 pm](https://cloud.githubusercontent.com/assets/848113/26422193/db7b3bc6-4096-11e7-85c6-89abcfc3082e.png)


Thanks!