### PR TITLE
Move the "images failed to load" message out of _handleSuccess

### DIFF
--- a/modules/Preload.js
+++ b/modules/Preload.js
@@ -64,7 +64,10 @@ class Preload extends Component {
                 .then(this._handleSuccess, this._handleError);
 
             if (this.props.autoResolveDelay && this.props.autoResolveDelay > 0) {
-                this.autoResolveTimeout = setTimeout(this._handleSuccess, this.props.autoResolveDelay);
+                this.autoResolveTimeout = setTimeout(() => {
+					console.warn('images failed to preload, auto resolving');
+					this._handleSuccess();
+				}, this.props.autoResolveDelay);
             }
         }
     }
@@ -79,7 +82,6 @@ class Preload extends Component {
     _handleSuccess() {
         if (this.autoResolveTimeout) {
             clearTimeout(this.autoResolveTimeout);
-            console.warn('images failed to preload, auto resolving');
         }
 
         if (this.state.ready || !this._mounted) {


### PR DESCRIPTION
As suggested by @Mesoptier, I moved the "images failed to load" warning out of the general _handleSuccess function, so it only appears when the timeout has actually been passed instead of just because a timeout parameter had been set.

This resolves issue #17 .